### PR TITLE
show all status of containers and a task.

### DIFF
--- a/tracer.go
+++ b/tracer.go
@@ -237,22 +237,17 @@ func (t *Tracer) traceTask(cluster string, taskID string) (*ecs.Task, error) {
 
 	for _, c := range task.Containers {
 		containerName := *c.Name
-		msg := fmt.Sprintf(*c.LastStatus)
+		msg := fmt.Sprintf("LastStatus:%s HealthStatus:%s", *c.LastStatus, *c.HealthStatus)
 		if c.ExitCode != nil {
 			msg += fmt.Sprintf(" (exit code: %d)", *c.ExitCode)
 		}
 		if c.Reason != nil {
 			msg += fmt.Sprintf(" (reason: %s)", *c.Reason)
 		}
-		var ts *time.Time
-		switch aws.StringValue(c.LastStatus) {
-		case "STOPPED":
-			ts = task.StoppedAt
-		default:
-			ts = &t.now
-		}
-		t.AddEvent(ts, "CONTAINER:"+containerName, msg)
+		t.AddEvent(&t.now, "CONTAINER:"+containerName, msg)
 	}
+
+	t.AddEvent(&t.now, "TASK", "LastStatus:"+aws.StringValue(task.LastStatus))
 
 	return task, nil
 }


### PR DESCRIPTION
e.g.

```
2022-03-01T14:39:22.513+09:00   TASK    Stopped
2022-03-01T14:41:08.121+09:00   CONTAINER:web   LastStatus:STOPPED HealthStatus:UNKNOWN (exit code: 1)
2022-03-01T14:41:08.121+09:00   CONTAINER:nginx LastStatus:STOPPED HealthStatus:UNKNOWN
2022-03-01T14:41:08.121+09:00   CONTAINER:envoy LastStatus:STOPPED HealthStatus:UNKNOWN (exit code: 0) (reason: CannotInspectContainerError: Could not transition to inspecting; timed out after waiting 30s)
2022-03-01T14:41:08.121+09:00   TASK    LastStatus:STOPPED
```