### PR TITLE
When executing from a lambda function, the SNS subject is too long when using ARNs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,12 @@ require (
 	github.com/aws/aws-lambda-go v1.28.0
 	github.com/aws/aws-sdk-go v1.42.12
 	github.com/pkg/errors v0.9.1
+	github.com/stretchr/testify v1.6.1
 )
 
-require github.com/jmespath/go-jmespath v0.4.0 // indirect
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,7 @@ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=

--- a/lambda_test.go
+++ b/lambda_test.go
@@ -1,0 +1,56 @@
+package tracer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractClusterName(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected string
+	}{
+		{
+			input:    "arn:aws:ecs:ap-northeast-1:012345678901:cluster/main",
+			expected: "main",
+		},
+		{
+			input:    "main",
+			expected: "main",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.input, func(t *testing.T) {
+			actual := extractClusterName(c.input)
+			require.Equal(t, c.expected, actual)
+		})
+	}
+}
+
+func TestExtractTaskID(t *testing.T) {
+	cases := []struct {
+		input    string
+		cluster  string
+		expected string
+	}{
+		{
+			input:    "0123456789abcdef0123456789abcdef",
+			cluster:  "main",
+			expected: "0123456789abcdef0123456789abcdef",
+		},
+		{
+			input:    "arn:aws:ecs:ap-northeast-1:012345678901:task/main/0123456789abcdef0123456789abcdef",
+			cluster:  "main",
+			expected: "0123456789abcdef0123456789abcdef",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.input, func(t *testing.T) {
+			actual := extractTaskID(c.cluster, c.input)
+			require.Equal(t, c.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
thank you great tool.

When executing from a lambda function, the SNS subject is too long when using ARNs

for example: 
```
Tracer: arn:aws:ecs:ap-northeast-1:012345678901:task/dev-main/0123456789abcdef0123456789abcdef on arn:aws:ecs:ap-northeast-1:012345678901:cluster/main
2022-03-23T03:34:40.757Z	TASK	Created
2022-03-23T03:34:44.431Z	TASK	Connected
2022-03-23T03:34:58.254Z	TASK	Pull started
2022-03-23T03:35:18.965Z	TASK	Pull stopped
2022-03-23T03:35:37.090Z	TASK	Started
2022-03-23T03:41:15.397Z	TASK	Execution stopped
2022-03-23T03:41:25.441Z	TASK	Stopping
2022-03-23T03:41:25.441Z	TASK	StoppedReason:Essential container in task exited
2022-03-23T03:41:25.441Z	TASK	StoppedCode:EssentialContainerExited
2022-03-23T03:41:38.629Z	TASK	Stopped
2022-03-23T03:44:32.977Z	CONTAINER:hoge	LastStatus:STOPPED HealthStatus:UNKNOWN (exit code: 0)
2022-03-23T03:44:32.977Z	TASK	LastStatus:STOPPED
InvalidParameter: Invalid parameter: Subject
```

from aws cli help message:
```

       --subject (string)
          Optional parameter to be used as the "Subject" line when the message
          is  delivered  to email endpoints. This field will also be included,
          if present, in the standard JSON messages delivered  to  other  end-
          points.

          Constraints:  Subjects must be ASCII text that begins with a letter,
          number, or punctuation mark; must not include line breaks or control
          characters; and must be less than 100 characters long.
```

Sending SNS fails because the subject is too long.
Therefore, we have made two changes.

1. cluster name and task ID are extracted from ARN in the Lambda handler.
2. if the Subject is longer than 100 characters, omit the end

