### PR TITLE
Remove `time.Time` fields from the type of input payload of lambda handler function.

### DIFF
--- a/events.go
+++ b/events.go
@@ -3,7 +3,6 @@ package tracer
 import (
 	"bytes"
 	"encoding/json"
-	"time"
 )
 
 type ECSTaskEvent struct {
@@ -13,10 +12,8 @@ type ECSTaskEvent struct {
 type ECSTaskEventDetail struct {
 	DesiredStatus string    `json:"desiredStatus"`
 	LastStatus    string    `json:"lastStatus"`
-	StartedAt     time.Time `json:"startedAt"`
 	StopCode      string    `json:"stopCode"`
 	StoppedReason string    `json:"stoppedReason"`
-	StoppingAt    time.Time `json:"stoppingAt"`
 	TaskArn       string    `json:"taskArn"`
 	ClusterArn    string    `json:"clusterArn"`
 }


### PR DESCRIPTION
Thank you for the awesome tool ❤️ 

# What This PR do?

Remove `time.Time` fields from the type of input payload of lambda handler function.

# Why?

To make it handle payload typed with [`Task`](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Task.html), like results of ECS tasks running on AWS Step Functions.

# Context

On AWS Step Functions, I'd like to collect error log from ECS Tasks with `tracer` deployed as a lambda function.

<img width="389" alt="image" src="https://user-images.githubusercontent.com/11021/187609387-10145898-c482-43d8-a48d-60ddb698f3a8.png">

And I got error like below.

```json
{
    "errorMessage": "parsing time \"1661779180572\" as \"\\\"2006-01-02T15:04:05Z07:00\\\"\": cannot parse \"1661779180572\" as \"\\\"\"",
    "errorType": "ParseError"
}
```

It's because `tracer` just expects payload from [`ECS events`](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_cwe_events.html#ecs_task_events) and tries to handle unixtime fields as `RFC3339`. 

This issue is noted as 

> The values for the createdAt, connectivityAt, pullStartedAt, startedAt, pullStoppedAt, and updatedAt fields are UNIX timestamps in the response of a DescribeTasks action whereas in the task state change event they are ISO string timestamps.

on [`ECS events`](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_cwe_events.html#ecs_task_events)


this patch might be uncool, but I think reasonable because the deleted fields are not referenced.
Thanks!