### PR TITLE
fetch logs after pull stopped + duration

### DIFF
--- a/tracer.go
+++ b/tracer.go
@@ -443,6 +443,10 @@ func (t *Tracer) setBoundaries(task *ecsTypes.Task) {
 	} else {
 		t.headEnd = task.CreatedAt.Add(d)
 	}
+	// logs are not output before pull stopped
+	if task.PullStoppedAt != nil {
+		t.headEnd = task.PullStoppedAt.Add(d)
+	}
 
 	if task.StoppingAt != nil {
 		t.tailBegin = task.StoppingAt.Add(-d)


### PR DESCRIPTION
tracer cannot fetch logs at task starting up when pull stage takes a long time (over `-duration` flag).

Basically, logs are not output before pull stopped.

